### PR TITLE
Update emulator config in e2e tests

### DIFF
--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -90,10 +90,12 @@ workflows:
         - project_location: ./_tmp
         - module: $TEST_APP_MODULE
         - variant: $TEST_APP_VARIANT
-    - git::https://github.com/bitrise-steplib/steps-avd-manager:
+    - avd-manager:
         inputs:
-        - abi: arm64-v8a
-    - git::https://github.com/bitrise-steplib/steps-wait-for-android-emulator: { }
+        - api_level: '30'
+        - abi: x86_64
+        - tag: google_apis_playstore
+    - git::https://github.com/bitrise-steplib/steps-wait-for-android-emulator.git@update-boot-check: {}
 
   run_tests:
     steps:

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -92,10 +92,10 @@ workflows:
         - variant: $TEST_APP_VARIANT
     - avd-manager:
         inputs:
-        - api_level: '30'
+        - api_level: "30"
         - abi: x86_64
         - tag: google_apis_playstore
-    - git::https://github.com/bitrise-steplib/steps-wait-for-android-emulator.git@update-boot-check: {}
+    - git::https://github.com/bitrise-steplib/steps-wait-for-android-emulator.git@update-boot-check: { }
 
   run_tests:
     steps:

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -85,7 +85,7 @@ workflows:
         run_if: .IsCI
         inputs:
         - gradlew_path: ./_tmp/gradlew
-    - git::https://github.com/bitrise-steplib/bitrise-step-android-build-for-ui-testing:
+    - android-build-for-ui-testing:
         inputs:
         - project_location: ./_tmp
         - module: $TEST_APP_MODULE
@@ -95,7 +95,7 @@ workflows:
         - api_level: "30"
         - abi: x86_64
         - tag: google_apis_playstore
-    - git::https://github.com/bitrise-steplib/steps-wait-for-android-emulator.git@update-boot-check: { }
+    - wait-for-android-emulator: { }
 
   run_tests:
     steps:

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -95,7 +95,7 @@ workflows:
         - api_level: "30"
         - abi: x86_64
         - tag: google_apis_playstore
-    - wait-for-android-emulator: { }
+    - git::https://github.com/bitrise-steplib/steps-wait-for-android-emulator.git@update-boot-check: { }
 
   run_tests:
     steps:


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version

Requires a NO* [version update](https://semver.org/)

### Context

This PR iterates on the e2e tests emulator config to make it more stable.

### Changes

- Use `android-build-for-ui-testing` Step from the StepLib
- Use `avd-manager` from the StepLib
- Use `api_level: "30"`, `abi: x86_64` and `tag: google_apis_playstore` as emulator config
- Use `wait-for-android-emulator` Step from the `update-boot-check` branch

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
