### PR TITLE
Update git url for generate_readme workflow

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -14,7 +14,7 @@ workflows:
 
   generate_readme:
     steps:
-    - git::https://github.com/bitrise-steplib/steps-readme-generator.git: { }
+    - git::https://github.com/bitrise-steplib/steps-readme-generator.git@main: { }
 
   sample:
     envs:


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version

~~Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)~~

We have yet to do an official release, but will do that after this is merged.

### Context

For a reasons I'm not aware of, the `steps-readme-generator` Step needs to have its `main` branch specified in the git URL in the `bitrise.yml` file. If it's omitted, then it tries to load a `master` branch, which is nonexistent. This is a known issue, so hopefully will be addressed at some point.

### Changes

- Adds `@main` to the end of the git URL for the `generate_readme` workflow.