### PR TITLE
Update GitHub URLs in step.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# Android Instrument Test
+# Android Instrumented Test
 
-[![Step changelog](https://shields.io/github/v/release/hisaac/bitrise-step-android-instrument-test?include_prereleases&label=changelog&color=blueviolet)](https://github.com/hisaac/bitrise-step-android-instrument-test/releases)
+[![Step changelog](https://shields.io/github/v/release/bitrise-steplib/bitrise-step-android-instrumented-test?include_prereleases&label=changelog&color=blueviolet)](https://github.com/bitrise-steplib/bitrise-step-android-instrumented-test/releases)
 
-Runs Instrument tests on an existing APK
+Runs Instrumented tests on an existing APK
 
 <details>
 <summary>Description</summary>
 
-Runs Instrument tests on an existing APK
+Runs Instrumented tests on an existing APK
 </details>
 
 ## 🧩 Get started
@@ -36,7 +36,7 @@ There are no outputs defined in this step
 
 ## 🙋 Contributing
 
-We welcome [pull requests](https://github.com/hisaac/bitrise-step-android-instrument-test/pulls) and [issues](https://github.com/hisaac/bitrise-step-android-instrument-test/issues) against this repository.
+We welcome [pull requests](https://github.com/bitrise-steplib/bitrise-step-android-instrumented-test/pulls) and [issues](https://github.com/bitrise-steplib/bitrise-step-android-instrumented-test/issues) against this repository.
 
 For pull requests, work on your changes in a forked repository and use the Bitrise CLI to [run step tests locally](https://devcenter.bitrise.io/bitrise-cli/run-your-first-build/).
 

--- a/step.yml
+++ b/step.yml
@@ -1,9 +1,9 @@
-title: Android Instrument Test
-summary: Runs Instrument tests on an existing APK
-description: Runs Instrument tests on an existing APK
-website: https://github.com/hisaac/bitrise-step-android-instrument-test
-source_code_url: https://github.com/hisaac/bitrise-step-android-instrument-test
-support_url: https://github.com/hisaac/bitrise-step-android-instrument-test/issues
+title: Android Instrumented Test
+summary: Runs Instrumented tests on an existing APK
+description: Runs Instrumented tests on an existing APK
+website: https://github.com/bitrise-steplib/bitrise-step-android-instrumented-test
+source_code_url: https://github.com/bitrise-steplib/bitrise-step-android-instrumented-test
+support_url: https://github.com/bitrise-steplib/bitrise-step-android-instrumented-test/issues
 host_os_tags:
 - osx-10.10
 - ubuntu-16.04
@@ -27,7 +27,7 @@ deps:
 
 toolkit:
   go:
-    package_name: github.com/hisaac/bitrise-step-android-instrument-test
+    package_name: github.com/bitrise-steplib/bitrise-step-android-instrumented-test
 
 inputs:
 - main_apk_path: $BITRISE_APK_PATH


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version

~~Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)~~

I will move the 0.1.0 to point to the commit of this merge.

### Context

I initially created this repo on my personal GitHub account, as we were still working to understand how we do it with Terraform.

### Changes

- Updates the GitHub URLs in the step.yml file from `hisaac` → `bitrise-steplib`.
- Updates usage of the word "Instrument" to "Instrumented" for accuracy.
- Regenerates the README.md.