### PR TITLE
Detect process crash

### DIFF
--- a/step/step.go
+++ b/step/step.go
@@ -134,8 +134,14 @@ func (testRunner InstrumentedTestRunner) Run(config Config) error {
 	}
 
 	// `adb` does not return an error exit code when tests fail, so we parse the test log instead
-	if strings.Contains(outputBuffer.String(), "FAILURES!!!") {
-		return fmt.Errorf("test run contained at least one test failure")
+	patterns := []string {
+		"FAILURES!!!",
+		"shortMsg=Process crashed.",
+	}
+	for _, pattern := range patterns {
+		if strings.Contains(outputBuffer.String(), pattern) {
+			return fmt.Errorf("test run contained at least one test failure")
+		}
 	}
 
 	return nil


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

A user report where the step is successful, even though this is the end of the adb output:

```
Caused by: android.system.ErrnoException: bind failed: EADDRINUSE (Address already in use)
	at libcore.io.Linux.bind(Native Method)
	at libcore.io.ForwardingOs.bind(ForwardingOs.java:60)
	at libcore.io.IoBridge.bind(IoBridge.java:99)
	... 37 more
com.[REDACTED].android.utils.AnalyticsUtilsAndroidTest:.
com.[REDACTED].android.views.BasketStepperViewTest:
.
.
.
.
.
.
INSTRUMENTATION_RESULT: shortMsg=Process crashed.
INSTRUMENTATION_CODE: 0
```

### Changes

Detect the process crash pattern too and count it as a failure.

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
